### PR TITLE
Bugfix: Reversed animation and onTap as seperate concepts in InkWell widget

### DIFF
--- a/lib/src/widgets/buttons/_button.dart
+++ b/lib/src/widgets/buttons/_button.dart
@@ -140,12 +140,10 @@ class NeuButtonState extends State<NeuButton>
       onTap: () {
         if (widget.enableAnimation) {
           _controller.forward().then((value) {
-            if (widget.onPressed != null) {
-              widget.onPressed!();
-              _controller.reverse();
-            }
+            _controller.reverse();
           });
-        } else if (widget.onPressed != null) {
+        }
+        if (widget.onPressed != null) {
           widget.onPressed!();
         }
       },

--- a/lib/src/widgets/buttons/_button.dart
+++ b/lib/src/widgets/buttons/_button.dart
@@ -138,13 +138,21 @@ class NeuButtonState extends State<NeuButton>
   Widget build(BuildContext context) {
     return InkWell(
       onTap: () {
+        var doOnPressedAction = () => {
+              if (widget.onPressed != null) {widget.onPressed!()}
+            };
+
         if (widget.enableAnimation) {
+          // do the on pressed action after the
+          // first part of animation
           _controller.forward().then((value) {
+            doOnPressedAction();
             _controller.reverse();
           });
-        }
-        if (widget.onPressed != null) {
-          widget.onPressed!();
+        } else {
+          // do on pressed action without any
+          // animation
+          doOnPressedAction();
         }
       },
       child: AnimatedBuilder(


### PR DESCRIPTION
This  change also does the widget.onPressed() once, regardless of where the animation is up to.

Currently, if onPressed is null, the animation will not reverse, as the button is "stuck down"

Also, if onPressed is not null, then it will call twice in the on-tap: once to start and again when animation is supposed to reverse.

we want to have animations and do onPressed() as separate things, so that we can click a button and still have the effect, and have the button do things.

## Status

**DEVELOPMENT**

## Description

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)