### PR TITLE
created neu_dialog and added padding to neu_container

### DIFF
--- a/example/lib/views/mobile_view.dart
+++ b/example/lib/views/mobile_view.dart
@@ -8,7 +8,35 @@ class MobileView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
+      /*floatingActionButton: FloatingActionButton(onPressed: () {
+        showDialog(
+          context: context,
+          builder: (context) {
+            return NeuDialog(
+                padding: EdgeInsets.all(16.0),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    FlutterLogo(
+                      size: MediaQuery.of(context).size.height * .20,
+                    ),
+                    const SizedBox(height: 8.0),
+                    const Text("NeuDialog Example"),
+                    const SizedBox(height: 8.0),
+                    NeuTextButton(
+                      buttonColor: Colors.yellow,
+                      enableAnimation: true,
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
+                      text: const Text("OK"),
+                    ),
+                  ],
+                ));
+          },
+        );
+      }),*/
       backgroundColor: Color(0xFFF0E4E4),
       body: Center(
         child: Column(

--- a/lib/src/widgets/containers/neu_container.dart
+++ b/lib/src/widgets/containers/neu_container.dart
@@ -33,6 +33,7 @@ class NeuContainer extends StatefulWidget {
     this.shadowBlurStyle = neuBlurStyle,
     this.child,
     this.borderRadius,
+    this.padding,
   }) : super(key: key);
 
   /// - offset (optional): An Offset that defines the position of the shadow of the container.
@@ -101,6 +102,12 @@ class NeuContainer extends StatefulWidget {
 
   final BorderRadiusGeometry? borderRadius;
 
+  /// - padding (optional): A EdgeInsetsGeometry that add inner padding to the container
+  ///
+  /// By default, it is set to null.
+
+  final EdgeInsetsGeometry? padding;
+
   @override
   State<NeuContainer> createState() => NeuContainerState();
 }
@@ -109,6 +116,7 @@ class NeuContainerState extends State<NeuContainer> {
   @override
   Widget build(BuildContext context) {
     return Container(
+      padding: widget.padding,
       width: widget.width,
       height: widget.height,
       decoration: BoxDecoration(

--- a/lib/src/widgets/dialog/neu_dialog.dart
+++ b/lib/src/widgets/dialog/neu_dialog.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:neubrutalism_ui/neubrutalism_ui.dart';
+
+class NeuDialog extends Dialog {
+  /// A [NeuDialog] box (Neubrutalism Dialog) with different customizable options.
+  ///
+  /// The [Dialog] has a customizable background color, border color,
+  /// and drop shadow. The Dialog's shape can also be customized with a rounded
+  /// border radius.
+  ///
+  /// [NeuDialog] also inherits following attributes from Dialog Widget class for further customization:
+  ///   1. insetAnimationDuration,
+  ///   2. insetAnimationCurve,
+  ///   3. insetPadding,
+  ///   4. clipBehavior,
+  ///   5. alignment,
+  ///
+  /// This [Dialog] Widget is built using Flutter's `Material` widget, and is designed to
+  /// follow the [Neubrutalism] UI style guidelines.
+  ///
+
+  /// Default [NeuDialog]
+  const NeuDialog({
+    super.key,
+    required this.child,
+    this.backgroundColor = Colors.white,
+    this.borderColor = neuBlack,
+    this.borderWidth = neuBorder,
+    this.borderRadius,
+    this.padding = const EdgeInsets.all(8.0),
+    this.shadowBlurRadius = neuShadowBlurRadius,
+    this.offset = neuOffset,
+    this.shadowBlurStyle = neuBlurStyle,
+    this.shadowColor = neuShadow,
+    this.fullscreen = false,
+    super.insetAnimationDuration,
+    super.insetAnimationCurve,
+    super.insetPadding,
+    super.clipBehavior,
+    super.alignment,
+  });
+
+  /// Fullscreen [NeuDialog]
+  const NeuDialog.fullscreen({
+    super.key,
+    required this.child,
+    this.fullscreen = true,
+    this.backgroundColor = Colors.white,
+    this.borderColor = neuBlack,
+    this.borderWidth = neuBorder,
+    this.borderRadius,
+    this.padding = const EdgeInsets.all(8.0),
+    this.shadowBlurRadius = neuShadowBlurRadius,
+    this.offset = neuOffset,
+    this.shadowBlurStyle = neuBlurStyle,
+    this.shadowColor = neuShadow,
+    super.insetAnimationDuration,
+    super.insetAnimationCurve,
+    super.insetPadding,
+    super.clipBehavior,
+    super.alignment,
+  });
+
+  /// - [child] (required): A widget that is displayed inside the [NeuDialog].
+  final Widget child;
+
+  /// - [fullscreen] (optional): A bool to allow fullscreen mode in [NeuDialog].
+  ///
+  /// By default, it is set to [false].
+  final bool fullscreen;
+
+  /// - [padding] (optional): A EdgeInsetsGeometry that add inner padding to the [NeuDialog].
+  ///
+  /// By default, it is set to const EdgeInsets.all(8.0).
+  final EdgeInsets padding;
+
+  /// - [backgroundColor] (optional): A Color that defines the background color of the [NeuDialog].
+  ///
+  /// By default, it is set to [white].
+  final Color? backgroundColor;
+
+  /// - [borderColor] (optional): A Color that defines the color of the border of the [NeuDialog].
+  ///
+  /// By default, it is set to [neuBlack].
+  final Color borderColor;
+
+  /// - [shadowColor] (optional): A Color that defines the color of the shadow of the [NeuDialog].
+  ///
+  /// By default, it is set to [neuShadow].
+  final Color shadowColor;
+
+  /// - [borderWidth] (optional): A double that defines the width of the border of the [NeuDialog].
+  ///
+  /// By default, it is set to [neuBorder].
+  final double borderWidth;
+
+  /// - [shadowBlurRadius] (optional): A double that defines the blur radius of the shadow of the [NeuDialog].
+  ///
+  /// By default, it is set to [neuShadowBlurRadius].
+  final double shadowBlurRadius;
+
+  /// - [shadowBlurStyle] (optional): A BlurStyle that defines the style of the blur of the shadow of the [NeuDialog].
+  ///
+  /// By default, it is set to [neuBlurStyle].
+  final BlurStyle shadowBlurStyle;
+
+  /// - [offset] (optional): An Offset that defines the position of the shadow of the [NeuDialog].
+  ///
+  /// By default, it is set to [neuOffset].
+  final Offset offset;
+
+  /// - [borderRadius] (optional): A BorderRadiusGeometry that defines the radius of the corners of the [NeuDialog].
+  ///
+  /// By default, it is set to null.
+  final BorderRadiusGeometry? borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    /// Main [NeuContainer]
+    final widget = NeuContainer(
+      child: child,
+      padding: padding,
+      color: this.backgroundColor,
+      offset: offset,
+      shadowColor: shadowColor,
+      shadowBlurRadius: shadowBlurRadius,
+      borderRadius: borderRadius,
+      borderColor: borderColor,
+      borderWidth: borderWidth,
+      shadowBlurStyle: shadowBlurStyle,
+    );
+
+    /// if fullscreen is enabled
+    /// return => Dialog.fullscreen
+    if (fullscreen) {
+      return Dialog.fullscreen(
+        insetAnimationDuration: insetAnimationDuration,
+        insetAnimationCurve: insetAnimationCurve,
+        child: widget,
+      );
+    }
+
+    /// Default Dialog
+    return Dialog(
+      alignment: alignment,
+      clipBehavior: clipBehavior,
+      insetAnimationCurve: insetAnimationCurve,
+      insetAnimationDuration: insetAnimationDuration,
+      insetPadding: insetPadding,
+      child: widget,
+    );
+  }
+}

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -6,3 +6,5 @@ export 'containers/neu_search_bar.dart';
 export 'containers/neu_container.dart';
 
 export './bottom nav/neu_bottom_nav.dart';
+
+export 'dialog/neu_dialog.dart';


### PR DESCRIPTION
## Status

**READY**

## Description

1. Created a new custom dialog box which follows Neubrutalism theme pattern, with features like customization(color, shadowColor, borderRadius etc), default and fullscreen view.
2. Added padding attribute to neu_container.dart for additional customization.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 🗑️ Chore

## Screenshot:

![Screenshot_20240415_121739](https://github.com/deepraj02/neubrutalism_ui/assets/16263958/f625291e-c16b-4974-acd3-8e89b76034f6)


